### PR TITLE
remove duplicate case label && fix spell mistakes

### DIFF
--- a/libs/classfile/classarea.js
+++ b/libs/classfile/classarea.js
@@ -60,7 +60,7 @@ var getClassImage = function(classBytes) {
 
     var classImage = {};
         
-    var getAttribues = function(attribute_name_index, bytes) {
+    var getAttributes = function(attribute_name_index, bytes) {
             
         var reader = new Reader.create(bytes);
         var attribute = { attribute_name_index: attribute_name_index };
@@ -172,20 +172,10 @@ var getClassImage = function(classBytes) {
                 var bytes = reader.readString(length);
                 classImage.constant_pool.push( { tag: tag, bytes: bytes } );
                 break;
-            case TAGS.CONSTANT_Methodref:
-                var class_index = reader.read16();
-                var name_and_type_index = reader.read16();
-                classImage.constant_pool.push( {  tag: tag, class_index: class_index, name_and_type_index: name_and_type_index } );
-                break;
             case TAGS.CONSTANT_NameAndType:
                 var name_index = reader.read16();
                 var signature_index = reader.read16();
                 classImage.constant_pool.push( { tag: tag, name_index: name_index,  signature_index: signature_index } );                
-                break;
-            case TAGS.CONSTANT_Fieldref:
-                var class_index = reader.read16();
-                var name_and_type_index = reader.read16();
-                classImage.constant_pool.push( { tag: tag, class_index: class_index,  name_and_type_index: name_and_type_index } );                                
                 break;
             case TAGS.CONSTANT_String:
                 var string_index = reader.read16();
@@ -278,7 +268,7 @@ var getClassImage = function(classBytes) {
         for(var j=0; j <attributes_count; j++) {
             var attribute_name_index = reader.read16();
             var attribute_length = reader.read32();
-            var info = getAttribues(attribute_name_index, reader.readBytes(attribute_length));            
+            var info = getAttributes(attribute_name_index, reader.readBytes(attribute_length));
             var attribute = {
                 attribute_name_index: attribute_name_index,
                 attribute_length: attribute_length,
@@ -296,7 +286,7 @@ var getClassImage = function(classBytes) {
     for(var i=0; i<attributes_count; i++) {
             var attribute_name_index = reader.read16();
             var attribute_length = reader.read32();
-            var info = getAttribues(attribute_name_index, reader.readBytes(attribute_length));            
+            var info = getAttributes(attribute_name_index, reader.readBytes(attribute_length));
             var attribute = {
                 attribute_name_index: attribute_name_index,
                 attribute_length: attribute_length,

--- a/libs/logger.js
+++ b/libs/logger.js
@@ -9,7 +9,7 @@ var LEVELS = {
     DEBUG:  1<<0,
     ERROR:  1<<1,
     INFO:   1<<2,
-    WARM:   1<<3,
+    WARN:   1<<3,
     check: function(levels, level) {
         return (levels & level) === level;
     }
@@ -17,7 +17,7 @@ var LEVELS = {
 
 var Logger = module.exports = function(levels) {
     if (this instanceof Logger) {
-        this.levels = levels || ( LEVELS.DEBUG | LEVELS.ERROR | LEVELS.INFO | LEVELS.WARM );
+        this.levels = levels || ( LEVELS.DEBUG | LEVELS.ERROR | LEVELS.INFO | LEVELS.WARN );
     } else {
         return new Logger(levels);
     }
@@ -46,7 +46,7 @@ Logger.prototype.info = function(msg) {
 }
 
 Logger.prototype.warn = function(msg) {
-    if (LEVELS.check(this.levels, LEVELS.WARM)) {
+    if (LEVELS.check(this.levels, LEVELS.WARN)) {
         util.print("WARN: " + msg);
     }
 }


### PR DESCRIPTION
1. fix some spell mistakes
2. remove two redundant case labels which are defined later in a switch branch